### PR TITLE
Update mamba install instructions

### DIFF
--- a/EZINSAR_BIN/docs/installation_instructions_mamba.md
+++ b/EZINSAR_BIN/docs/installation_instructions_mamba.md
@@ -2,88 +2,135 @@
 
 Author: Maria del Mar Quiroga (University of Melbourne)
 
-Date: 14 June 2023
+Modified by: Romain Beucher (ACCESS-NRI) / Madhiyeh Razeghi (USQ)
 
-Source: https://github.com/alexisInSAR/EZ-InSAR/issues/54 
+Date: 17 October 2023
 
 ***
 
-1. Install mamba and other ubuntu and python libraries. Open a terminal and paste:
-```
-curl -L -O https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-Linux-x86_64.sh
-bash Mambaforge-Linux-x86_64.sh 
-sudo apt install gcc g++ gawk tcsh build-essential make git
-pip install wget gitpython tree mamba
+## Requirements
+
+Install base utilities for your system. Here we assume you are running an Ubuntu Linux system.
+
+```bash
+sudo apt-get update
+sudo apt-get install -y build-essential
+sudo apt-get install -y wget unzip git vim
+sudo apt-get clean
+sudo rm -rf /var/lib/apt/lists/*
 ```
 
-2. Create a Python virtual environment. In the same terminal:
-```
-sudo apt install python3.8-venv
-python -m venv InSARenv
-source InSARenv/bin/activate
-````
+## Create an InSARenv Conda environment using Mamba
 
-3. Install InSAR processing packages and EZ-InSAR. In the same terminal:
+Miniforge provides a minimal conda/mamba installation which should be sufficient to run EZ_InSAR.
+
+In your `$HOME` directory, we are going to install conda/mamba in the `conda` folder.
+
+```bash
+export CONDA_DIR=$HOME/conda
+
+wget --quiet https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+
+bash Miniforge3-Linux-x86_64.sh -b -p $CONDA_DIR
+```
+
+Put conda in path so we can use `mamba` without having to specify its full path.
+
+```bash
+export PATH=$CONDA_DIR/bin:$PATH
+```
+
+ Make sure `mamba` and `pip` are up to date and create the **InSARenv** environment.
+
+```bash
+mamba update -y  mamba pip
+mamba create --name InSARenv
+```
+
+## Install InSAR processing packages and EZ-InSAR. 
+
+In the same terminal:
+
 ```
 EZINSAR_HOME="$HOME"
 tools_insar=$EZINSAR_HOME/tools_insar
 tool_DIR=$tools_insar/proc_insar
 sudo mkdir -p $tool_DIR
 ```
+
+Get the different modules from GitHub:
+
 ```
-sudo git clone https://github.com/alexisInSAR/EZ-InSAR.git $tools_insar/EZ-InSAR
+git clone https://github.com/alexisInSAR/EZ-InSAR.git $tools_insar/EZ-InSAR
 sudo mv $tools_insar/EZ-InSAR $tools_insar/EZINSAR
-sudo git clone https://github.com/isce-framework/isce2.git $tool_DIR/isce2  
-sudo git clone https://github.com/insarlab/MintPy.git      $tool_DIR/MintPy 
-sudo git clone https://github.com/insarwxw/StaMPS.git      $tool_DIR/StaMPS
-sudo git clone https://github.com/dbekaert/TRAIN.git       $tool_DIR/StaMPS/TRAIN
-```
-```
-sudo cp $tools_insar/EZINSAR/EZINSAR_BIN/docs/config_InSARenv.template $tools_insar/config_InSARenv.rc
-sudo sed -i "/EZINSAR_HOME=/c\EZINSAR_HOME=$EZINSAR_HOME"  $tools_insar/config_InSARenv.rc
-sudo sed -i "/APS_toolbox=/c\APS_toolbox=$tool_DIR/StaMPS/TRAIN" $tool_DIR/StaMPS/TRAIN/APS_CONFIG.sh
+git clone https://github.com/isce-framework/isce2.git $tool_DIR/isce2  
+git clone https://github.com/insarlab/MintPy.git      $tool_DIR/MintPy 
+git clone https://github.com/insarwxw/StaMPS.git      $tool_DIR/StaMPS
+git clone https://github.com/dbekaert/TRAIN.git       $tool_DIR/StaMPS/TRAIN
 ```
 
-4. Add the following lines to your .bashrc file:
-````
+Create/Modify the `configInSARenv.rc` file
+
+```
+cp $tools_insar/EZINSAR/EZINSAR_BIN/docs/config_InSARenv.template $tools_insar/config_InSARenv.rc
+sed -i "/EZINSAR_HOME=/c\EZINSAR_HOME=$EZINSAR_HOME"  $tools_insar/config_InSARenv.rc
+sed -i "/APS_toolbox=/c\APS_toolbox=$tool_DIR/StaMPS/TRAIN" $tool_DIR/StaMPS/TRAIN/APS_CONFIG.sh
+```
+
+**Init mamba (not just conda!)**. This will add the relevant `source` command to your `.bashrc`
+
+I recommend setting `auto_activate_base` to `false`
+
+```bash
+mamba init
+conda config --set auto_activate_base false
+```
+
+Add the following lines to your .bashrc file:
+
+```bash
 # EZ-InSAR & InSARenv
-EZINSAR_HOME="$HOME"                                          
+EZINSAR_HOME="$HOME"                                    
 export tools_insar="$EZINSAR_HOME/tools_insar"
+export tool_DIR=$tools_insar/proc_insar
 alias load_insar='conda activate InSARenv; source $tools_insar/config_InSARenv.rc'
-````
-
-Vim instructions:
-
-On the terminal type
-
-```vi ~/.bashrc```
-
-
-This will change the terminal to show your bashrc file on screen. Use the down arrow to go to the bottom of the file. Press the letter i, and the word "-- INSERT --" will appear at the bottom. Now copy the previous few lines, and paste them at the end of the file (right-click -> Paste). Press "Esc" key once, then ":" key, "w" key, and "q" key, then "Enter".
-
-Then you will be back on the regular terminal. Run:
-
 ```
-source ~/.bashrc
+
+> [!NOTE]  
+> Vim instructions:
+>
+>On the terminal type
+>
+>```vim ~/.bashrc```
+>
+>This will change the terminal to show your bashrc file on screen. Use the down arrow to go to the bottom of the file. Press the letter i, and the word "-- INSERT --" will appear at the bottom. Now copy the previous few lines, and paste them at the end of the file (right-click -> Paste). Press "Esc" key once, then ":" key, "w" key, and "q" key, then "Enter".
+
+
+**Open a new terminal and run:**
+
+```bash
 load_insar
 ```
 
-5. Install ISCE. On the same terminal:
-```
+### Install ISCE. On the same terminal:
+
+```bash
 mamba  install -c conda-forge isce2
- 
 cd $tool_DIR
 mamba install -c conda-forge --file ./MintPy/requirements.txt
 ```
 
-7. Install MintPy. **Close the terminal and restart** for above changes to take effect!
-```
-sudo python -m pip install -e ./MintPy
+### Install MintPy
+
+```bash
+pip install -e ./MintPy
 ```
 
-8. Install StaMPS
+### Install StaMPS
 
-```
+Make sure we have the relevant compilers installed:
+
+```bash
 sudo apt install software-properties-common
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt install -y gcc-7 g++-7
@@ -92,27 +139,34 @@ sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 7
 sudo update-alternatives --config gcc
 sudo update-alternatives --config g++
 ```
+
+Now build `StaMPS`:
+
 ```
 cd $tool_DIR/StaMPS/src
-sudo make
-sudo make install
+make
+make install
+```
 
+```
 sudo apt install snaphu 
 sudo apt install triangle-bin
 ```
 
-9. Install EZ-InSAR
-```
+### Install EZ-InSAR
+
+```bash
 mamba install fiona geopandas rasterio
 
 cd $tool_DIR
  
-sudo curl https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o "awscliv2.zip"
-sudo unzip awscliv2.zip
+wget https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o "awscliv2.zip"
+unzip awscliv2.zip
 sudo ./aws/install
 ```
 
-10. Set your ASF account and credentials. If using vim again, type:
+Set your ASF account and credentials. If using vim again, type:
+
 ```
 vi ../EZINSAR/EZINSAR_BIN/pathinformation.txt
 ```
@@ -124,7 +178,9 @@ ASFPWD  password
 ```
 Once it's all good, "Esc", ":", "w", "q", "Enter". You should be back in the terminal.
 
-11. Run MATLAB from the terminal. Type:
+### Run Matlab
+
+Run MATLAB from the terminal. Type:
 ```
 matlab 
 ```

--- a/EZINSAR_BIN/docs/installation_instructions_mamba.md
+++ b/EZINSAR_BIN/docs/installation_instructions_mamba.md
@@ -4,7 +4,7 @@ Author: Maria del Mar Quiroga (University of Melbourne)
 
 Modified by: Romain Beucher (ACCESS-NRI) / Madhiyeh Razeghi (USQ)
 
-Date: 17 October 2023
+Date: 17 November 2023
 
 ***
 


### PR DESCRIPTION
Hi,

Thanks for all the work and for providing the package to the community.

We spent quite a bit of time trying to figure out how to install the packages in a `mamba` environment.
I took the liberty to update some of the instructions. This might be useful to others.

- I am using **Miniforge**. I believe this is the most lightweight option.
- The old version was creating a Python virtual environment, not a conda environment.
- `mamba init` should be run not just `conda init`

Romain
